### PR TITLE
✨Feat: 채널 유입 경로 조회 api

### DIFF
--- a/src/main/java/codepirate/tubelensbe/funnel/Repository/FunnelYoutubeConfig.java
+++ b/src/main/java/codepirate/tubelensbe/funnel/Repository/FunnelYoutubeConfig.java
@@ -1,0 +1,20 @@
+package codepirate.tubelensbe.funnel.Repository;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.support.RestClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+@Configuration
+public class FunnelYoutubeConfig {
+
+    private final RestClient restClient = RestClient.builder().build();
+    private final RestClientAdapter adapter = RestClientAdapter.create(restClient);
+    private final HttpServiceProxyFactory factory = HttpServiceProxyFactory.builderFor(adapter).build();
+
+    @Bean
+    public FunnelYoutubeRepository trafficSourceRepository() {
+        return factory.createClient(FunnelYoutubeRepository.class);
+    }
+}

--- a/src/main/java/codepirate/tubelensbe/funnel/Repository/FunnelYoutubeRepository.java
+++ b/src/main/java/codepirate/tubelensbe/funnel/Repository/FunnelYoutubeRepository.java
@@ -1,0 +1,24 @@
+package codepirate.tubelensbe.funnel.Repository;
+
+import codepirate.tubelensbe.funnel.dto.AnalyticsReportResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.HttpExchange;
+
+@Component
+@HttpExchange("https://youtubeanalytics.googleapis.com/v2")
+public interface FunnelYoutubeRepository {
+
+    @GetExchange("/reports")
+    AnalyticsReportResponse getFunnelResponse(
+            @RequestHeader("Authorization") String authorization,
+            @RequestParam String ids,
+            @RequestParam String startDate,
+            @RequestParam String endDate,
+            @RequestParam String metrics,
+            @RequestParam String dimensions,
+            @RequestParam String sort
+    );
+}

--- a/src/main/java/codepirate/tubelensbe/funnel/controller/FunnelController.java
+++ b/src/main/java/codepirate/tubelensbe/funnel/controller/FunnelController.java
@@ -1,0 +1,24 @@
+package codepirate.tubelensbe.funnel.controller;
+
+import codepirate.tubelensbe.funnel.dto.FunnelResponse;
+import codepirate.tubelensbe.funnel.service.FunnelService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/funnel")
+public class FunnelController {
+
+    private final FunnelService funnelService;
+
+    @PostMapping()
+    public FunnelResponse getFunnel(
+            @RequestHeader("Authorization") String token
+            ) {
+        return funnelService.getFunnel(token);
+    }
+}

--- a/src/main/java/codepirate/tubelensbe/funnel/dto/AnalyticsReportResponse.java
+++ b/src/main/java/codepirate/tubelensbe/funnel/dto/AnalyticsReportResponse.java
@@ -1,0 +1,19 @@
+package codepirate.tubelensbe.funnel.dto;
+
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class AnalyticsReportResponse {
+    private String kind;
+    private List<ColumnHeader> columnHeaders;
+    private List<List<Object>> rows;
+
+    @Data
+    public static class ColumnHeader {
+        private String name;
+        private String columnType;
+        private String dataType;
+    }
+}
+

--- a/src/main/java/codepirate/tubelensbe/funnel/dto/FunnelResponse.java
+++ b/src/main/java/codepirate/tubelensbe/funnel/dto/FunnelResponse.java
@@ -1,0 +1,20 @@
+package codepirate.tubelensbe.funnel.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class FunnelResponse {
+    private double EXT_URL;
+    private double YT_SEARCH;
+    private double RELATED_VIDEO;
+    private double PLAYLIST;
+    private double SUBSCRIBER;
+    private double CHANNEL;
+    private double NOTIFICATION;
+    private double ADVERTISING;
+    private double etc;
+}

--- a/src/main/java/codepirate/tubelensbe/funnel/service/FunnelService.java
+++ b/src/main/java/codepirate/tubelensbe/funnel/service/FunnelService.java
@@ -1,0 +1,75 @@
+package codepirate.tubelensbe.funnel.service;
+
+import codepirate.tubelensbe.funnel.Repository.FunnelYoutubeRepository;
+import codepirate.tubelensbe.funnel.dto.AnalyticsReportResponse;
+import codepirate.tubelensbe.funnel.dto.FunnelResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FunnelService {
+
+    private final FunnelYoutubeRepository funnelYoutubeRepository;
+
+    public FunnelResponse getFunnel(String token) {
+        AnalyticsReportResponse funnel = funnelYoutubeRepository.getFunnelResponse(
+                token,
+                "channel==MINE",
+                LocalDate.now().minusMonths(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd")),
+                LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")),
+                "views,estimatedMinutesWatched",
+                "insightTrafficSourceType",
+                "-views"
+        );
+
+        FunnelResponse.FunnelResponseBuilder builder = FunnelResponse.builder();
+
+        if (funnel.getRows() != null) {
+            for (List<Object> row : funnel.getRows()) {
+                if (row.size() >= 2) {
+                    String type = row.get(0).toString();
+                    long views = Long.parseLong(row.get(1).toString());
+
+                    switch (type) {
+                        case "EXT_URL":
+                            builder.EXT_URL(views);
+                            break;
+                        case "YT_SEARCH":
+                            builder.YT_SEARCH(views);
+                            break;
+                        case "RELATED_VIDEO":
+                            builder.RELATED_VIDEO(views);
+                            break;
+                        case "PLAYLIST":
+                            builder.PLAYLIST(views);
+                            break;
+                        case "SUBSCRIBER":
+                            builder.SUBSCRIBER(views);
+                            break;
+                        case "CHANNEL":
+                            builder.CHANNEL(views);
+                            break;
+                        case "NOTIFICATION":
+                            builder.NOTIFICATION(views);
+                            break;
+                        case "ADVERTISING":
+                            builder.ADVERTISING(views);
+                            break;
+                        default:
+                            builder.etc(views); // 기타 유입경로
+                            break;
+                    }
+                }
+            }
+        }
+
+        return builder.build();
+    }
+}


### PR DESCRIPTION
📌PR 유형  
[ ✅ ] 새로운 기능 추가  
[ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)  
[ ] 코드 리팩토링  
[ ] 주석 추가 및 수정

🔍변경 사항  
채널의 유입 경로를 조회하는 api입니다.
헤더에 oauth token 담아 보내면 본인 채널의 한 달 간 유입경로 조회할 수 있습니다.

✅ PR Checklist  
[ ✅ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  
[ ✅ ] 변경 사항을 로컬에서 테스트 했습니다.  
[ ✅ ] 라벨을 선택했습니다.